### PR TITLE
fix 'self' in csp specification

### DIFF
--- a/lib/PicoFarad/Response.php
+++ b/lib/PicoFarad/Response.php
@@ -123,7 +123,7 @@ function csp(array $policies = array())
 
             foreach ($hosts as &$host) {
 
-                if ($host === '*' || $host === 'self' || strpos($host, 'http') === 0) {
+                if ($host === '*' || $host === "'self'" || strpos($host, 'http') === 0) {
                     $acl .= $host.' ';
                 }
             }


### PR DESCRIPTION
This fixes the usage of `'self'` for content security policy. The single quotes around `'self'` are required, otherwise it is ignored.